### PR TITLE
Get stats for any list of params

### DIFF
--- a/fandomstats/api/views.py
+++ b/fandomstats/api/views.py
@@ -1,15 +1,32 @@
 from flask import render_template, jsonify, request
 from fandomstats.api import api
-from models import AO3data
+from models import AO3data, AO3url
 
 version_base = '/v1.0' 
+
+# Stats for any search filter
+@api.route(version_base+"/stats", methods=['GET'])
+def getStats():
+  # Returns stats for any list of search arguments
+  s = AO3data()
+  url = AO3url()
+  url.setFilters(request.args)
+  s.searchURL = url.getUrl()
+  s.getTopInfo()
+  return jsonify({ 'stats': s.categories })
 
 # Tag Stats
 @api.route(version_base+"/stats/tag/<tag_id>", methods=['GET'])
 def getTagStats(tag_id):
+  # todo: possibly remove completely? possibly unnecessary?
   # todo: add error handling for empty tagid
+  params = {
+    "type": "works",
+    "params": {
+      "tag_id": tag_id
+    } 
+  }
   s = AO3data()
-  s.tag_id = tag_id
-  s.createSearchURL()
+  s.searchURL = AO3url().getUrl(params) 
   s.getTopInfo()
   return jsonify({ 'stats': s.categories })

--- a/fandomstats_tests.py
+++ b/fandomstats_tests.py
@@ -2,6 +2,7 @@ import os
 import fandomstats
 import unittest
 import tempfile
+from werkzeug import datastructures 
 from fandomstats.api.models import AO3url 
 
 class FandomstatsTestCase(unittest.TestCase):
@@ -9,6 +10,7 @@ class FandomstatsTestCase(unittest.TestCase):
     def setUp(self):
       fandomstats.app.config['TESTING'] = True
       self.app = fandomstats.app.test_client()
+      self.maxDiff = None
 
     def test_tag_search(self):
       t = {
@@ -18,8 +20,7 @@ class FandomstatsTestCase(unittest.TestCase):
             }
           }
       expected = "http://archiveofourown.org/works?tag_id=Harry+Potter"
-      a = AO3url(t)
-      url = a.getUrl()
+      url = AO3url().getUrl(t)
       self.assertEqual(url, expected)
         
     def test_tag_search_moderately_complex(self):
@@ -36,8 +37,7 @@ class FandomstatsTestCase(unittest.TestCase):
             }
           }
       expected = "http://archiveofourown.org/works?work_search%5Bsort_column%5D=hits&work_search%5Bwarning_ids%5D%5B%5D=16&work_search%5Bwarning_ids%5D%5B%5D=14&work_search%5Bwarning_ids%5D%5B%5D=18&work_search%5Brating_ids%5D%5B%5D=11&work_search%5Bcomplete%5D=1&tag_id=Harry+Potter"
-      a = AO3url(t)
-      url = a.getUrl()
+      url = AO3url().getUrl(t)
       self.assertEqual(url, expected)
 
     def test_tag_search_complex(self):
@@ -52,15 +52,57 @@ class FandomstatsTestCase(unittest.TestCase):
                 "category_ids": [23],
                 "fandom_ids":[136512],
                 "character_ids":[1803,1589,1048],
-                "other_tag_names":"Draco Malfoy",
+                "other_tag_names":["Draco Malfoy", "Harry Potter"],
                 "complete":0
               }
             }
           }
-      expected = 'http://archiveofourown.org/works?work_search%5Bcomplete%5D=0&work_search%5Bsort_column%5D=revised_at&work_search%5Bcategory_ids%5D%5B%5D=23&work_search%5Bcharacter_ids%5D%5B%5D=1803&work_search%5Bcharacter_ids%5D%5B%5D=1589&work_search%5Bcharacter_ids%5D%5B%5D=1048&work_search%5Bfandom_ids%5D%5B%5D=136512&work_search%5Bother_tag_names%5D=Draco+Malfoy&work_search%5Brating_ids%5D%5B%5D=13&page=3&tag_id=Draco+Malfoy%2FHarry+Potter'
-      a = AO3url(t)
-      url = a.getUrl()
+      expected = 'http://archiveofourown.org/works?work_search%5Bcomplete%5D=0&work_search%5Bsort_column%5D=revised_at&work_search%5Bcategory_ids%5D%5B%5D=23&work_search%5Bcharacter_ids%5D%5B%5D=1803&work_search%5Bcharacter_ids%5D%5B%5D=1589&work_search%5Bcharacter_ids%5D%5B%5D=1048&work_search%5Bfandom_ids%5D%5B%5D=136512&work_search%5Bother_tag_names%5D%5B%5D=Draco+Malfoy&work_search%5Bother_tag_names%5D%5B%5D=Harry+Potter&work_search%5Brating_ids%5D%5B%5D=13&page=3&tag_id=Draco+Malfoy%2FHarry+Potter'
+      url = AO3url().getUrl(t)
       self.assertEqual(url, expected)
+
+    def test_create_filters(self):
+      args = datastructures.ImmutableMultiDict([
+        ("page",3),
+        ("tag_id","Harry Potter"),
+        ("rating_ids",12),
+        ("rating_ids",13),
+        ("complete",1),
+        ("sort_direction","desc")
+      ])
+      expected = {
+        "type":"works",
+        "params": {
+          "page": 3,
+          "tag_id": "Harry Potter",
+          "sort_direction":"desc",
+          "work_search": {
+            "query": "",
+            "title": "",
+            "creator": "",
+            "revised_at": "",
+            "complete": 1,
+            "single_chapter": 0,
+            "rating_ids": [12, 13],
+            "warning_ids": [],
+            "category_ids": [],
+            "fandom_names": [],
+            "fandom_ids": [],
+            "character_names": [],
+            "character_ids": [],
+            "relationship_names": [],
+            "relationship_ids": [],
+            "freeform_names": [],
+            "freeform_ids": [],
+            "other_tag_names": [],
+            "other_tag_ids": [],
+            "sort_column": ""
+          }
+        } 
+      }
+      a = AO3url()
+      a.setFilters(args)
+      self.assertEqual(a.getFilters(), expected)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
To address https://github.com/esgibter/fandomstats/issues/6

This adds support for a new api endpoint at 

```
/api/v1.0/stats
```

Any list of search parameters can be added to this endpoint, e.g.:

```
/api/v1.0/stats?tag_id=Harry+Potter&complete=1&character_ids=1589&character_ids=1048&sort_direction=desc&page=2
```

And the Tag Stats data is returned.

What the code does in the AO3url class is convert the URL params into the filters object, which is then sent into the URL creator. 

Design notes:
- I chose to do URL parameters, like the example above, and consume them as the response arguments, instead of sending it via HTTP data params (like the example here: http://flask-restless.readthedocs.org/en/latest/searchformat.html) Technically it's easier for us to support it as a data param, but I thought that was more opaque if our goal was to enable other folks to consume our API. Take a look - if this doesn't seem like the right way to go I can turn it into data params pretty easily, or we could support both. 
- With the addition of the `/stats` API, we could choose to do away with the `/stats/tag/` API completely. `/stats/tag/` is a more specific version of `/stats` and is now redundant. Opinions welcome on this - I don't know if just the tag search by itself will be very useful - I'm pretty sure we'll want to add filters pretty early on in the UI, which would mean consuming `/stats` instead of `/stats/tag/`.
