### PR TITLE
Redirection

### DIFF
--- a/src/application/api/models.py
+++ b/src/application/api/models.py
@@ -4,19 +4,10 @@ from bs4 import BeautifulSoup
 import urllib3
 import urllib
 import pdb
-from flask.ext.restful import abort 
+from flask.ext.restful import abort
 
 class AO3url:
   # default filters object
-  filters = {
-    "type":"works",
-    "params": {
-      "tag_id": "",
-      "page": 1,
-      "sort_direction": "asc",
-      "work_search": {}
-    }
-  }
 
   def getFilters(self):
     return self.filters
@@ -44,6 +35,15 @@ class AO3url:
  
   def setFilters(self, urlArgs):
     # This sets the filters object from a list of URL arguments
+    self.filters = {
+               "type":"works",
+               "params": {
+                          "tag_id": "",
+                          "page": 1,
+                          "sort_direction": "asc",
+                          "work_search": {}
+                          }
+               }    
     for k, v in urlArgs.iteritems():
       if v != None:
         if k == "tag_id" or k == "page" or k == "sort_direction":

--- a/src/application/api/models.py
+++ b/src/application/api/models.py
@@ -4,6 +4,7 @@ from bs4 import BeautifulSoup
 import urllib3
 import urllib
 import pdb
+import inspect
 from flask.ext.restful import abort
 
 class AO3url:
@@ -61,8 +62,20 @@ class AO3data:
       http = urllib3.PoolManager()
       r = {}
       try:
-        r = http.request('GET', url)
+        r = http.request('GET', url,redirect=False)
+        #status = r.getcode()
+        status = r.getheader('status')
+        location = r.getheader('location')
+        print ""
+        print "status: " + status
+        print "proper location: " + location
+        print ""
+        #urllib3.response.HTTPResponse
         soup = BeautifulSoup(r.data)
+        #ret = r.get_redirect_location()
+        #headers = r.getheaders()
+        #print dir(r) #all methods/params of an object
+        #print inspect.ismethod(r.get_redirect_location)
         soup.prettify()                
         self.htmlData = soup
         return soup

--- a/src/application/api/models.py
+++ b/src/application/api/models.py
@@ -79,6 +79,7 @@ class AO3data:
             canonical_url = r.getheader('location')
             canonical_list = canonical_url.split("/") 
             canonical_tag = canonical_list[len(canonical_list)-2]
+            canonical_tag = urllib.unquote_plus(canonical_tag)
             raise Exception(302,canonical_tag) 
         elif status == "404 Not Found": # = malformed url or the tag doesn't exist
             #you can't abort from a try..catch block (http://stackoverflow.com/questions/17746897/flask-abort-inside-try-block-behaviour), so I'll throw an exception and handle that later.

--- a/src/application/api/views.py
+++ b/src/application/api/views.py
@@ -43,6 +43,8 @@ class Stats(Resource):
   # Stats for any search filter
   def get(self):
     # Returns stats for any list of search arguments
+    print "-------------------------"
+    print "======= NEW CYCLE ======="
     s = AO3data()
     url = AO3url()
     url.setFilters(parser.parse_args())

--- a/src/application/api/views.py
+++ b/src/application/api/views.py
@@ -43,9 +43,9 @@ class Stats(Resource):
   # Stats for any search filter
   def get(self):
     # Returns stats for any list of search arguments
-    print "-------------------------"
-    print "======= NEW CYCLE ======="
-    s = AO3data()
+    # print "-------------------------"
+    # print "======= NEW CYCLE ======="
+    s = AO3data(request.url)
     url = AO3url()
     url.setFilters(parser.parse_args())
     return s.getTopInfo(url.getUrl())


### PR DESCRIPTION
In this branch, I'm trying to fix the problem with AO3 redirect-to-canonical dropping params (issue #47)
(I also accidentally do #19 when catching status codes/error messages)

This is the lazy version: return 400 Bad Request, with the canonical tag in the message. Users would repeat their call with the canonical tag on their own.

The other option is to rerun the call with the canonical tag automaticaly. This brings A LOT of new issues: 
* it would require a nigh-complete rewrite of both AO3url and AO3data in a way that would allow that.  (I tried. My head hurts.) 
* we would need to add time-out to the script, to avoid hitting AO3 server too often. We also can't let the user hang in the air for 10 seconds, though. What do? We could maintain our own db table with canonical tag pairs, check against it before calling AO3, and only re-run when we encounter a new redirect. Not sure if possible? How big would the db get? And it still doesn't solve the problem of needing a time-out in those cases.