### PR TITLE
work_search tags API fix

### DIFF
--- a/src/application/api/models.py
+++ b/src/application/api/models.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 import sys
 import re
 from bs4 import BeautifulSoup
@@ -33,9 +35,11 @@ class AO3url:
       if type(v) is dict:
         for wk, wv in v.iteritems():
           if type(wv) is list:
-            # go through each value in the list
+            quoted_list = []
             for xv in wv:
-              url += urllib.quote_plus("work_search[" + wk + "][]") + "=" + self.quote(xv) + "&"
+                quoted_list.append(self.quote(xv))           
+            url += urllib.quote_plus("work_search[" + wk + "]") + "=" + ",".join(quoted_list) + "&"
+            
           else:
             url += urllib.quote_plus("work_search[" + wk + "]") + "=" + self.quote(wv) + "&"
       else:
@@ -50,6 +54,7 @@ class AO3url:
                "type":"works",
                "params": {
                           "tag_id": "",
+                          "utf8":"✓",
                           "page": 1,
                           "sort_direction": "asc",
                           "work_search": {}

--- a/src/application/api/views.py
+++ b/src/application/api/views.py
@@ -52,7 +52,8 @@ class Stats(Resource):
     s = AO3data(request.url)
     url = AO3url()
     url.setFilters(parser.parse_args())
-    return s.getTopInfo(url.getUrl())
+    parsed_url = url.getUrl()
+    return s.getTopInfo(parsed_url)
 
 class TagStats(Resource):
 

--- a/src/tests/Ao3url_test.py
+++ b/src/tests/Ao3url_test.py
@@ -36,7 +36,22 @@ class Ao3urlTestCase(unittest.TestCase):
       expected = "http://archiveofourown.org/works?tag_id=%EB%B0%A9%ED%83%84%EC%86%8C%EB%85%84%EB%8B%A8+%7C+Bangtan+Boys+%7C+BTS"
       url = AO3url().getUrl(t)
       self.assertEqual(url, expected)
-        
+    
+    
+    def test_getUrl_other_tag_names(self):
+        t = {
+             "type":"works",
+             "params": {
+                "tag_id":"Fluff",
+                "work_search": {
+                  "other_tag_names":"Angst"
+                }
+              }
+             }  
+        expected = "http://archiveofourown.org/works?work_search%5Bother_tag_names%5D=Angst&tag_id=Fluff"
+        url = AO3url().getUrl(t)
+        self.assertEqual(url, expected)
+          
     def test_getUrl_moderately_complex(self):
       t = {
             "type":"works",
@@ -50,7 +65,7 @@ class Ao3urlTestCase(unittest.TestCase):
               }
             }
           }
-      expected = "http://archiveofourown.org/works?work_search%5Bsort_column%5D=hits&work_search%5Bwarning_ids%5D%5B%5D=16&work_search%5Bwarning_ids%5D%5B%5D=14&work_search%5Bwarning_ids%5D%5B%5D=18&work_search%5Brating_ids%5D%5B%5D=11&work_search%5Bcomplete%5D=1&tag_id=Harry+Potter"
+      expected = "http://archiveofourown.org/works?work_search%5Bsort_column%5D=hits&work_search%5Bwarning_ids%5D=16,14,18&work_search%5Brating_ids%5D=11&work_search%5Bcomplete%5D=1&tag_id=Harry+Potter"
       url = AO3url().getUrl(t)
       self.assertEqual(url, expected)
 
@@ -71,7 +86,7 @@ class Ao3urlTestCase(unittest.TestCase):
               }
             }
           }
-      expected = 'http://archiveofourown.org/works?work_search%5Bcomplete%5D=0&work_search%5Bsort_column%5D=revised_at&work_search%5Bcategory_ids%5D%5B%5D=23&work_search%5Bcharacter_ids%5D%5B%5D=1803&work_search%5Bcharacter_ids%5D%5B%5D=1589&work_search%5Bcharacter_ids%5D%5B%5D=1048&work_search%5Bfandom_ids%5D%5B%5D=136512&work_search%5Bother_tag_names%5D%5B%5D=Draco+Malfoy&work_search%5Bother_tag_names%5D%5B%5D=Harry+Potter&work_search%5Brating_ids%5D%5B%5D=13&page=3&tag_id=Draco+Malfoy%2FHarry+Potter'
+      expected = 'http://archiveofourown.org/works?work_search%5Bcomplete%5D=0&work_search%5Bsort_column%5D=revised_at&work_search%5Bcategory_ids%5D=23&work_search%5Bcharacter_ids%5D=1803,1589,1048&work_search%5Bfandom_ids%5D=136512&work_search%5Bother_tag_names%5D=Draco+Malfoy,Harry+Potter&work_search%5Brating_ids%5D=13&page=3&tag_id=Draco+Malfoy%2FHarry+Potter'
       url = AO3url().getUrl(t)
       self.assertEqual(url, expected)
 
@@ -88,6 +103,7 @@ class Ao3urlTestCase(unittest.TestCase):
         "params": {
           "page": 3,
           "tag_id": "Harry Potter",
+          "utf8":"✓",
           "sort_direction":"desc",
           "work_search": {
             "complete": 1,


### PR DESCRIPTION
Fixes bug #62 - it seems that AO3 changed the format of `work_search` parameters: it now doesn't take multiple serialized parameters, but has just one with all the tags separated by commas. I.e.:
```
...&work_search[warning_ids]=14,16,18&...
```
instead of 
```
...&work_search[warning_ids][]=14&work_search[warning_ids][]=16&work_search[warning_ids][]=18&...
```
Which, hey! Nice! But the API broke, understandably. 

(I wonder if we shouldn't have some way of testing it. It's not quite unit testing - "integration testing" is the term, I think? Oh, well - yet another thing to go on the wishlist.)