### PR TITLE
Multi tag search

### DIFF
--- a/src/application/api/models.py
+++ b/src/application/api/models.py
@@ -38,7 +38,7 @@ class AO3url:
             quoted_list = []
             for xv in wv:
                 quoted_list.append(self.quote(xv))           
-            url += urllib.quote_plus("work_search[" + wk + "]") + "=" + ",".join(quoted_list) + "&"
+            url += urllib.quote_plus("work_search[" + wk + "]") + "=" + "%2C".join(quoted_list) + "&"
             
           else:
             url += urllib.quote_plus("work_search[" + wk + "]") + "=" + self.quote(wv) + "&"

--- a/src/application/api/views.py
+++ b/src/application/api/views.py
@@ -21,18 +21,31 @@ try:
     parser.add_argument("single_chapter", type=int)
     parser.add_argument("sort_column", type=str)
     parser.add_argument("rating_ids", type=int, action="append")
+    parser.add_argument("rating_ids[]", type=int, action="append")
     parser.add_argument("warning_ids", type=int, action="append")
+    parser.add_argument("warning_ids[]", type=int, action="append")
     parser.add_argument("category_ids", type=int, action="append")
+    parser.add_argument("category_ids[]", type=int, action="append")
     parser.add_argument("fandom_names", type=unicode, action="append")
+    parser.add_argument("fandom_names[]", type=unicode, action="append")
     parser.add_argument("fandom_ids", type=int, action="append")
+    parser.add_argument("fandom_ids[]", type=int, action="append")
     parser.add_argument("character_names", type=unicode, action="append")
+    parser.add_argument("character_names[]", type=unicode, action="append")
     parser.add_argument("character_ids", type=int, action="append")
+    parser.add_argument("character_ids[]", type=int, action="append")
     parser.add_argument("relationship_names", type=unicode, action="append")
+    parser.add_argument("relationship_names[]", type=unicode, action="append")
     parser.add_argument("relationship_ids", type=int, action="append")
+    parser.add_argument("relationship_ids[]", type=int, action="append")
     parser.add_argument("freeform_names", type=unicode, action="append")
+    parser.add_argument("freeform_names[]", type=unicode, action="append")
     parser.add_argument("freeform_ids", type=int, action="append")
+    parser.add_argument("freeform_ids[]", type=int, action="append")
     parser.add_argument("other_tag_names", type=unicode, action="append")
+    parser.add_argument("other_tag_names[]", type=unicode, action="append")
     parser.add_argument("other_tag_ids", type=int, action="append")
+    parser.add_argument("other_tag_ids[]", type=int, action="append")
     parser.add_argument("word_count", type=str)
     parser.add_argument("hits", type=str)
     parser.add_argument("kudos_count", type=str)
@@ -48,11 +61,44 @@ class Stats(Resource):
   def get(self):
     # Returns stats for any list of search arguments
     # print "-------------------------"
-    # print "======= NEW CYCLE ======="
+    #print "======= NEW CYCLE ======="
     s = AO3data(request.url)
     url = AO3url()
-    url.setFilters(parser.parse_args())
+    args = parser.parse_args()
+    #print "parsed args:"
+    #print args
+    serialArgs = [
+                  'rating_ids',
+                  'warning_ids',
+                  'category_ids',
+                  'fandom_names',
+                  'fandom_ids',
+                  'character_names',
+                  'character_ids',
+                  'relationship_names',
+                  'relationship_ids',
+                  'freeform_names',
+                  'freeform_ids',
+                  'other_tag_names',
+                  'other_tag_ids',
+                  ]
+    
+    for sArg in serialArgs:
+        if (args[sArg] == None and args[sArg + '[]'] == None):
+            continue
+        if (args[sArg+'[]'] == None):
+            continue
+        if (args[sArg] == None):
+            args[sArg] = args[sArg+'[]']
+            continue
+        else:
+            args[sArg] = args[sArg]+args[sArg + '[]']
+            args.pop(sArg + '[]')    
+        
+    url.setFilters(args)
     parsed_url = url.getUrl()
+    #print "parsed url:"
+    #print parsed_url
     return s.getTopInfo(parsed_url)
 
 class TagStats(Resource):

--- a/src/application/home/static/js/homepage.js
+++ b/src/application/home/static/js/homepage.js
@@ -141,8 +141,6 @@ $(".searchform").submit(function(e){
 			//LIVE*/
 			$(".api-results").show('fast');
 			
-			searchform.append('<p class="form-info">To better understand what the graphs are saying, check out "<a href="/reading-the-data">Reading the Data</a>".</p>');
-			
 			var graphs = $("#main-graphs");
 			graphs.css("visibility","visible");
 			

--- a/src/application/home/templates/homepage.html
+++ b/src/application/home/templates/homepage.html
@@ -30,10 +30,11 @@
 	
 	<hr class="splitter" />
 	
-	<h3 id="api-header">Get stats for an AO3 tag</h3>
+	<h3 id="api-header">Get stats for AO3 tags</h3>
 	<form id="searchform-homepage" class="row collapse bigform searchform">
+		<p class="form-info">You can search for a tag or a combination of tags - in that case, use double quotes around tags with spaces. To better understand what the graphs are saying, check out "<a href="/reading-the-data">Reading the Data</a>".</p>
 		<div class="large-10 medium-9 small-12 columns">
-	          <input id="search-string" type="text" placeholder="tag name, e.g. 'Harry Potter', or 'fluff'" autocomplete="off">
+			<input id="search-string" type="text" placeholder="one or more tag names ('Harry Potter', or '\"Harry Potter\" Fluff')" autocomplete="off">
     	</div>
     	<div class="large-2 medium-3 small-12 columns">
           <a href="#" id="search-btn" class="button postfix">Go</a>

--- a/src/tests/Ao3url_test.py
+++ b/src/tests/Ao3url_test.py
@@ -65,7 +65,7 @@ class Ao3urlTestCase(unittest.TestCase):
               }
             }
           }
-      expected = "http://archiveofourown.org/works?work_search%5Bsort_column%5D=hits&work_search%5Bwarning_ids%5D=16,14,18&work_search%5Brating_ids%5D=11&work_search%5Bcomplete%5D=1&tag_id=Harry+Potter"
+      expected = "http://archiveofourown.org/works?work_search%5Bsort_column%5D=hits&work_search%5Bwarning_ids%5D=16%2C14%2C18&work_search%5Brating_ids%5D=11&work_search%5Bcomplete%5D=1&tag_id=Harry+Potter"
       url = AO3url().getUrl(t)
       self.assertEqual(url, expected)
 
@@ -86,7 +86,7 @@ class Ao3urlTestCase(unittest.TestCase):
               }
             }
           }
-      expected = 'http://archiveofourown.org/works?work_search%5Bcomplete%5D=0&work_search%5Bsort_column%5D=revised_at&work_search%5Bcategory_ids%5D=23&work_search%5Bcharacter_ids%5D=1803,1589,1048&work_search%5Bfandom_ids%5D=136512&work_search%5Bother_tag_names%5D=Draco+Malfoy,Harry+Potter&work_search%5Brating_ids%5D=13&page=3&tag_id=Draco+Malfoy%2FHarry+Potter'
+      expected = 'http://archiveofourown.org/works?work_search%5Bcomplete%5D=0&work_search%5Bsort_column%5D=revised_at&work_search%5Bcategory_ids%5D=23&work_search%5Bcharacter_ids%5D=1803%2C1589%2C1048&work_search%5Bfandom_ids%5D=136512&work_search%5Bother_tag_names%5D=Draco+Malfoy%2CHarry+Potter&work_search%5Brating_ids%5D=13&page=3&tag_id=Draco+Malfoy%2FHarry+Potter'
       url = AO3url().getUrl(t)
       self.assertEqual(url, expected)
 


### PR DESCRIPTION
This enables searching for multiple tags at the same time (i.e. "Harry Potter" and "Fluff"), by parsing quoted strings.

This enables the most requested feature (searching for tag combinations) without having to add any GUI. The API technically has one "main tag" and several "other tags", but I checked and the result is same no matter which tag is the main one. 

It does make the form a bit more confusing though.

What do you think? 