### PR TITLE
the tag search input field now parses multiple tags as comma-separated

### DIFF
--- a/src/application/home/static/js/homepage.js
+++ b/src/application/home/static/js/homepage.js
@@ -83,37 +83,12 @@ $(".searchform").submit(function(e){
 	var tagAPI = {};
 	tagAPI.url = "/api/v1.0/stats";
 	var searchString = $("#search-string").val();
-	var quoteCount = 0;
-	var unquoted = '';
-	for (var i = 0, len = searchString.length; i < len; i++) {
-		c = searchString.charAt(i);
-		if (c == '"') {
-			quoteCount++;
-		} else {
-			unquoted+= c;
-		}
-	}
-	var tags=[];
-	var other_tags = [];
 	
-	if (quoteCount <= 1) {
-		main_tag = unquoted;
-		tags.push(main_tag);
-	} else {
-		var tags = [];
-		var re = /[^\s"']+|"([^"]*)"|'([^']*)'/g;
-		var resultArr = [];
-		while ((resultArr = re.exec(searchString)) !== null) {
-			if (resultArr[1] == undefined) {
-				tags.push(resultArr[0]);
-			} else {
-				tags.push(resultArr[1]);
-			}
-		}
-		main_tag = tags[0];
-		other_tags = tags.slice(1,tags.length);
-	}
-	var params = {};
+	var tags = searchString.split(",");
+	
+	main_tag = tags[0];
+	other_tags = tags.slice(1);
+	
 	/*TEST
 	$.ajax({
 		url:"/home/static/js/dummy.json",

--- a/src/application/home/templates/homepage.html
+++ b/src/application/home/templates/homepage.html
@@ -32,9 +32,9 @@
 	
 	<h3 id="api-header">Get stats for AO3 tags</h3>
 	<form id="searchform-homepage" class="row collapse bigform searchform">
-		<p class="form-about">You can search for a tag or a combination of tags - in that case, use double quotes around tags with spaces. To better understand what the graphs are saying, check out "<a href="/reading-the-data">Reading the Data</a>".</p>
+		<p class="form-about">You can search for a single tag, or a combination of tags. To better understand what the graphs are saying, check out "<a href="/reading-the-data">Reading the Data</a>".</p>
 		<div class="large-10 medium-9 small-12 columns">
-			<input id="search-string" type="text" placeholder="one or more tag names ('Harry Potter', or '&quot;Harry Potter&quot; Fluff')" autocomplete="off">
+			<input id="search-string" type="text" placeholder="one or more comma-separated tag names (i.e. 'Harry Potter', 'Star Wars, Fluff')" autocomplete="off">
     	</div>
     	<div class="large-2 medium-3 small-12 columns">
           <a href="#" id="search-btn" class="button postfix">Go</a>


### PR DESCRIPTION
Fixes #76  [reported by an anon on Tumblr](https://fandomstatsorg.tumblr.com/post/166509029009/does-your-fandomstats-page-have-trouble-with-tags).

Solved by replacing the quote system with commas. Because, as per [AO3 Tags FAQ](http://archiveofourown.org/faq/tags?language_id=en#tagformat), tags cannot contain commas. Obviously. \*facepalm*



