### PR TITLE
Https error

### DIFF
--- a/src/application/api/models.py
+++ b/src/application/api/models.py
@@ -29,7 +29,7 @@ class AO3url:
     else:
       self.filters = filters
     # Creates URL from search parameters
-    url = "http://archiveofourown.org/"
+    url = "https://archiveofourown.org/"
     url += self.filters['type'] + "?"
     for k, v in self.filters['params'].iteritems():
       if type(v) is dict:
@@ -79,10 +79,10 @@ class AO3data:
   # METHOD: fetchHTML
   def fetchHTML(self, url):
     if self.htmlData == {}:            
-      http = urllib3.PoolManager()
+      http = urllib3.PoolManager(headers={'user-agent':'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36'})
       r = {}
       try:
-          #print "url: {}".format(url) #TODO the API dies with an uncaught 500 error when it times out while accessing AO3
+          print "url: {}".format(url) #TODO the API dies with an uncaught 500 error when it times out while accessing AO3
           r = http.request('GET', url,redirect=False)
           redirect_loc = r.get_redirect_location()
             
@@ -92,6 +92,7 @@ class AO3data:
               soup = BeautifulSoup(r.data)
               soup.prettify()                
               self.htmlData = soup
+              print ">>>>>>GOT THE DATA"
           elif isinstance(redirect_loc,basestring): #redirecting somewhere
               if (redirect_loc.find("/works") == -1): #it's a tag that can't be filtered on
                   raise ValueError(404,"")

--- a/src/application/api/models.py
+++ b/src/application/api/models.py
@@ -81,7 +81,7 @@ class AO3data:
     if self.htmlData == {}:            
       try:
           #pdb.set_trace()
-          print "url: {}".format(url) #TODO the API dies with an uncaught 500 error when it times out while accessing AO3
+          #print "url: {}".format(url) #TODO the API dies with an uncaught 500 error when it times out while accessing AO3
           #url = "https://archiveofourown.org/works?tag_id=Star+Wars"
           try:
 			  r = urllib2.urlopen(url)
@@ -96,7 +96,7 @@ class AO3data:
               soup = BeautifulSoup(r)
               soup.prettify()                
               self.htmlData = soup
-              print ">>>>>>GOT THE DATA"
+              #print ">>>>>>GOT THE DATA"
           else: #redirecting somewhere
 			  #it's a tag that can't be filtered on
 			  if (final_url.find("/works") == -1):

--- a/src/application/api/views.py
+++ b/src/application/api/views.py
@@ -59,9 +59,9 @@ class Stats(Resource):
   
   # Stats for any search filter
   def get(self):
-    # Returns stats for any list of search arguments
-    # print "-------------------------"
-    #print "======= NEW CYCLE ======="
+    #Returns stats for any list of search arguments
+    print "-------------------------"
+    print "======= NEW CYCLE ======="
     s = AO3data(request.url)
     url = AO3url()
     args = parser.parse_args()

--- a/src/application/api/views.py
+++ b/src/application/api/views.py
@@ -60,8 +60,8 @@ class Stats(Resource):
   # Stats for any search filter
   def get(self):
     #Returns stats for any list of search arguments
-    print "-------------------------"
-    print "======= NEW CYCLE ======="
+    #print "-------------------------"
+    #print "======= NEW CYCLE ======="
     s = AO3data(request.url)
     url = AO3url()
     args = parser.parse_args()

--- a/src/application/home/views.py
+++ b/src/application/home/views.py
@@ -1,6 +1,7 @@
 from flask import render_template, jsonify, request
 from application import app
 from application.home import home
+import urllib3
 
 # Homepage
 @home.route("/")
@@ -36,3 +37,15 @@ def howto():
 @home.route("/google137e022a821ce1e1.html")
 def GSC_file():
   return app.send_static_file('google137e022a821ce1e1.html')
+  
+  
+# Testing urllib3 fetch of a https site
+@home.route("/urllib3_test")
+def urllib3_test():
+  url = "http://portfolio.corvidism.com"
+  ssl_url = "https://crowdraws.tumblr.com/"
+  http = urllib3.PoolManager(headers={'user-agent':'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36'})
+  r = {}
+  r = http.request('GET', ssl_url,redirect=False)
+  #eeeyup, this is borked on GAE.
+  return str(r.headers)

--- a/src/application/home/views.py
+++ b/src/application/home/views.py
@@ -1,7 +1,8 @@
 from flask import render_template, jsonify, request
 from application import app
 from application.home import home
-import urllib3
+#import urllib3
+from google.appengine.api import urlfetch
 
 # Homepage
 @home.route("/")
@@ -44,8 +45,16 @@ def GSC_file():
 def urllib3_test():
   url = "http://portfolio.corvidism.com"
   ssl_url = "https://crowdraws.tumblr.com/"
-  http = urllib3.PoolManager(headers={'user-agent':'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36'})
-  r = {}
-  r = http.request('GET', ssl_url,redirect=False)
-  #eeeyup, this is borked on GAE.
-  return str(r.headers)
+  #http = urllib3.PoolManager(headers={'user-agent':'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36'})
+  #r = {}
+  #r = http.request('GET', ssl_url,redirect=False)
+  try:
+      result = urlfetch.fetch(ssl_url)
+      if result.status_code == 200:
+        output = str(result.headers)
+      else:
+          output = "error"
+  except urlfetch.Error:
+      logging.exception('Caught exception fetching url')
+
+  return str(output)

--- a/src/application/home/views.py
+++ b/src/application/home/views.py
@@ -1,8 +1,6 @@
 from flask import render_template, jsonify, request
 from application import app
 from application.home import home
-#import urllib3
-from google.appengine.api import urlfetch
 
 # Homepage
 @home.route("/")
@@ -38,23 +36,3 @@ def howto():
 @home.route("/google137e022a821ce1e1.html")
 def GSC_file():
   return app.send_static_file('google137e022a821ce1e1.html')
-  
-  
-# Testing urllib3 fetch of a https site
-@home.route("/urllib3_test")
-def urllib3_test():
-  url = "http://portfolio.corvidism.com"
-  ssl_url = "https://crowdraws.tumblr.com/"
-  #http = urllib3.PoolManager(headers={'user-agent':'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36'})
-  #r = {}
-  #r = http.request('GET', ssl_url,redirect=False)
-  try:
-      result = urlfetch.fetch(ssl_url)
-      if result.status_code == 200:
-        output = str(result.headers)
-      else:
-          output = "error"
-  except urlfetch.Error:
-      logging.exception('Caught exception fetching url')
-
-  return str(output)

--- a/src/tests/Ao3data_test.py
+++ b/src/tests/Ao3data_test.py
@@ -2,7 +2,6 @@ import os,sys
 sys.path.insert(1, os.path.join(os.path.abspath('.'), 'lib'))
 import application as fandomstats
 import unittest
-import requests
 import tempfile
 from werkzeug import datastructures 
 from application.api.models import AO3data
@@ -19,13 +18,14 @@ class Ao3dataTestCase(unittest.TestCase):
         url = "boingboing"
         a = AO3data(url)
         
+        
         with self.assertRaises(ValueError) as context:
             data = a.fetchHTML(url)
         
         self.assertEquals(context.exception.args[0],400)
     
     def test_fetchHTML_nonexistent_tag(self):
-        url = "http://archiveofourown.org/works?tag_id=boingboing"
+        url = "https://archiveofourown.org/works?tag_id=boingboing"
         a = AO3data(url)
         
         with self.assertRaises(ValueError) as context:
@@ -35,7 +35,7 @@ class Ao3dataTestCase(unittest.TestCase):
     
     @unittest.skip("not yet")    
     def test_fetchHTML_basic(self):
-        url = "http://archiveofourown.org/works?tag_id=Harry+Potter"
+        url = "https://archiveofourown.org/works?tag_id=Harry+Potter"
         expected = []
         a = AO3data(url)
         self.assertEqual(a.fetchHTML(url),expected)

--- a/src/tests/Ao3url_test.py
+++ b/src/tests/Ao3url_test.py
@@ -22,7 +22,7 @@ class Ao3urlTestCase(unittest.TestCase):
               "tag_id":"Harry Potter"
             }
           }
-      expected = "http://archiveofourown.org/works?tag_id=Harry+Potter"
+      expected = "https://archiveofourown.org/works?tag_id=Harry+Potter"
       url = AO3url().getUrl(t)
       self.assertEqual(url, expected)
       
@@ -33,7 +33,7 @@ class Ao3urlTestCase(unittest.TestCase):
               "tag_id":"방탄소년단 | Bangtan Boys | BTS"
             }
           }
-      expected = "http://archiveofourown.org/works?tag_id=%EB%B0%A9%ED%83%84%EC%86%8C%EB%85%84%EB%8B%A8+%7C+Bangtan+Boys+%7C+BTS"
+      expected = "https://archiveofourown.org/works?tag_id=%EB%B0%A9%ED%83%84%EC%86%8C%EB%85%84%EB%8B%A8+%7C+Bangtan+Boys+%7C+BTS"
       url = AO3url().getUrl(t)
       self.assertEqual(url, expected)
     
@@ -48,7 +48,7 @@ class Ao3urlTestCase(unittest.TestCase):
                 }
               }
              }  
-        expected = "http://archiveofourown.org/works?work_search%5Bother_tag_names%5D=Angst&tag_id=Fluff"
+        expected = "https://archiveofourown.org/works?work_search%5Bother_tag_names%5D=Angst&tag_id=Fluff"
         url = AO3url().getUrl(t)
         self.assertEqual(url, expected)
           
@@ -65,7 +65,7 @@ class Ao3urlTestCase(unittest.TestCase):
               }
             }
           }
-      expected = "http://archiveofourown.org/works?work_search%5Bsort_column%5D=hits&work_search%5Bwarning_ids%5D=16%2C14%2C18&work_search%5Brating_ids%5D=11&work_search%5Bcomplete%5D=1&tag_id=Harry+Potter"
+      expected = "https://archiveofourown.org/works?work_search%5Bsort_column%5D=hits&work_search%5Bwarning_ids%5D=16%2C14%2C18&work_search%5Brating_ids%5D=11&work_search%5Bcomplete%5D=1&tag_id=Harry+Potter"
       url = AO3url().getUrl(t)
       self.assertEqual(url, expected)
 
@@ -86,7 +86,7 @@ class Ao3urlTestCase(unittest.TestCase):
               }
             }
           }
-      expected = 'http://archiveofourown.org/works?work_search%5Bcomplete%5D=0&work_search%5Bsort_column%5D=revised_at&work_search%5Bcategory_ids%5D=23&work_search%5Bcharacter_ids%5D=1803%2C1589%2C1048&work_search%5Bfandom_ids%5D=136512&work_search%5Bother_tag_names%5D=Draco+Malfoy%2CHarry+Potter&work_search%5Brating_ids%5D=13&page=3&tag_id=Draco+Malfoy%2FHarry+Potter'
+      expected = 'https://archiveofourown.org/works?work_search%5Bcomplete%5D=0&work_search%5Bsort_column%5D=revised_at&work_search%5Bcategory_ids%5D=23&work_search%5Bcharacter_ids%5D=1803%2C1589%2C1048&work_search%5Bfandom_ids%5D=136512&work_search%5Bother_tag_names%5D=Draco+Malfoy%2CHarry+Potter&work_search%5Brating_ids%5D=13&page=3&tag_id=Draco+Malfoy%2FHarry+Potter'
       url = AO3url().getUrl(t)
       self.assertEqual(url, expected)
 

--- a/src/tests/integration_api_basic_test.py
+++ b/src/tests/integration_api_basic_test.py
@@ -2,7 +2,6 @@ import os,sys,json
 sys.path.insert(1, os.path.join(os.path.abspath('.'), 'lib'))
 import application as fandomstats
 import unittest
-import requests
 import tempfile
 from werkzeug import datastructures 
 


### PR DESCRIPTION
AO3 now forces https, which broke the API. Urllib3 failed with https on GAE, so I had to switch to a different library. I chose urllib2 - requests would be better, but it would require third-party-package installation, and just... no.